### PR TITLE
add: custom retry callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,30 +269,30 @@ function createRequestRetry (requestImpl, reply, retriesCount, retryOnError, max
           return retryAfter
         }
 
-        const defaultRetryLogic = (retryAfter) => {
+        const defaultRetry = () => {
           if (res && res.statusCode === 503 && req.method === 'GET') {
             if (retriesCount === 0 && retries < maxRetriesOn503) {
               // we should stop at some point
-              return retryAfter
+              return true
             }
           } else if (retriesCount > retries && err && err.code === retryOnError) {
-            return retryAfter
+            return true
           }
+          return false
         }
 
 
         if (!reply.sent) {
           if (customRetry && customRetry.handler){
-           const retryAfter = customRetry.handler(req, res, defaultRetryAfter, defaultRetryLogic)
+           const retryAfter = customRetry.handler(req, res, defaultRetryAfter, defaultRetry)
             if (retryAfter){
               if (++retries < customRetry.retries){
                 return retry(retryAfter)
               }
             }
           }else{
-            const defaultAfter = defaultRetryAfter()
-            if (defaultRetryLogic(defaultAfter)){
-              return retry(defaultAfter)
+            if (defaultRetry()){
+              return retry(defaultRetryAfter())
             }
           }
         }

--- a/index.js
+++ b/index.js
@@ -283,10 +283,10 @@ function createRequestRetry (requestImpl, reply, retriesCount, retryOnError, max
 
         if (!reply.sent) {
           if (customRetry && customRetry.handler){
-           const customRetryAfter = customRetry.handler(req, res, defaultRetryAfter, defaultRetryLogic)
-            if (customRetryAfter){
+           const retryAfter = customRetry.handler(req, res, defaultRetryAfter, defaultRetryLogic)
+            if (retryAfter){
               if (++retries < customRetry.retries){
-                return retry(customRetryAfter)
+                return retry(retryAfter)
               }
             }
           }else{

--- a/test/retry-on-500.test.js
+++ b/test/retry-on-500.test.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const From = require('..')
+const http = require('node:http')
+const got = require('got')
+
+function createTargetServer (withRetryAfterHeader, stopAfter = 2) {
+  let requestCount = 0
+  return http.createServer((req, res) => {
+    if (requestCount++ < stopAfter) {
+      res.statusCode = 500
+      res.setHeader('Content-Type', 'text/plain')
+
+      if (withRetryAfterHeader) {
+        res.setHeader('Retry-After', 100) // 100 ms
+      }
+
+      return res.end('This Service is Unavailable')
+    }
+
+    res.statusCode = 200
+    res.setHeader('Content-Type', 'text/plain')
+    return res.end(`Hello World After ${requestCount}`)
+  })
+}
+
+test("custom retries on the server", async function (t) {
+  const customRetryLogic = ({...opts}) => {
+    if (opts.res && opts.res.statusCode === 500 && opts.req.method === 'GET'){
+      return 100
+    }
+    return null
+  }
+
+  const target = createTargetServer()
+  await target.listen({ port: 0 })
+  t.teardown(target.close.bind(target))
+
+  const instance = Fastify()
+  instance.register(From, {
+    base: `http://localhost:${target.address().port}`
+  })
+
+  instance.get('/', (request, reply) => {
+    console.log('getting reply from broken serve')
+    reply.from(`http://localhost:${target.address().port}`, {
+      customRetryHandler: { retries: 10, retryHandlerImpl: customRetryLogic }
+    })
+  })
+
+  t.teardown(instance.close.bind(instance))
+  await instance.listen({ port: 0 })
+
+  // ----- End Registering The Fastify Server ---
+
+  // making a request to the server we setup through fastify
+  const res = await got.get(`http://localhost:${instance.server.address().port}`, { retry: 0 })
+  console.log('request to server', { statusCode: res.statusCode, body: res.body.toString() })
+})

--- a/test/retry-on-500.test.js
+++ b/test/retry-on-500.test.js
@@ -5,38 +5,37 @@ const Fastify = require('fastify')
 const From = require('..')
 const http = require('node:http')
 const got = require('got')
+const { InternalServerError } = require('../lib/errors')
 
-function internalErrorServerWhichRevives (withRetryAfterHeader, stopAfter = 4) {
+function serverWithCustomError (stopAfter, statusCodeToFailOn) {
   let requestCount = 0
   return http.createServer((req, res) => {
     if (requestCount++ < stopAfter) {
-      res.statusCode = 500
+      res.statusCode = statusCodeToFailOn
       res.setHeader('Content-Type', 'text/plain')
-      if (withRetryAfterHeader) {
-        res.setHeader('Retry-After', 100) // 100 ms
-      }
-
       return res.end('This Service is Unavailable')
+    }else{
+      res.statusCode = 205
+      res.setHeader('Content-Type', 'text/plain')
+      return res.end(`Hello World ${requestCount}!`)
     }
 
-    res.statusCode = 205
-    res.setHeader('Content-Type', 'text/plain')
-    return res.end(`Hello World ${requestCount}!`)
   })
 }
 
+//test cases queue
+// -> a server just 503's and as have a custom handler attached and we register the default
+// -> a server just 503's and we have a custom handler and we don't register the default. expect to 503
+// -> a server 503's and we don't have a custom handler we should still revive
 
 
+// -> server 500's with a custom handler and we revive but then we 503 without registering we should ultimately fail
+// -> a server 500's with a custom handler and we revive but then we 503 with registering
 
-test('retry a 500 status code in a custom manner', async function (t) {
-  const customRetryLogic = (req, res, registerDefaultRetry, defaultRetryAfter) => {
-    if (res && res.statusCode === 500 && req.method === 'GET') {
-      return 300
-    }
-    return null
-  }
 
-  const target = internalErrorServerWhichRevives(true)
+// -> a server 500's and we don't have a custom handler we should fail
+async function setupServer(t, fromOptions= {}, stopAfter = 4, statusCodeToFailOn = 500){
+  const target = serverWithCustomError(stopAfter, statusCodeToFailOn)
   await target.listen({ port: 0 })
   t.teardown(target.close.bind(target))
 
@@ -46,64 +45,75 @@ test('retry a 500 status code in a custom manner', async function (t) {
   })
 
   instance.get('/', (request, reply) => {
-    console.log('getting reply from broken serve')
-    reply.from(`http://localhost:${target.address().port}`, {
-      customRetry: { retries: 10, handler: customRetryLogic }
-    })
+    reply.from(`http://localhost:${target.address().port}`, fromOptions)
   })
 
   t.teardown(instance.close.bind(instance))
   await instance.listen({ port: 0 })
 
-  // ----- End Registering The Fastify Server ---
-
-  // making a request to the server we setup through fastify
-  const res = await got.get(`http://localhost:${instance.server.address().port}`, { retry: 0 })
-  console.log('request to server', { statusCode: res.statusCode, body: res.body.toString()})
-
-  t.equal(res.headers['content-type'], 'text/plain')
-  t.equal(res.statusCode, 205)
-  t.equal(res.body.toString(), 'Hello World 5!')
-})
-
-
-
-const create503ServerWhichRevivesAfterRetries = async () => {
-  let retryCount = 0;
-
-  return http.createServer((req, res) => {
-    if (retryCount++ < 2){
-      res.statusCode = 503
-      res.setHeader('Content-Type', 'text/plain')
-      res.setHeader('retry-after', 200)
-      return res.end('This Service is Unavailable')
-    }else{
-      res.statusCode = 205
-      res.setHeader('Content-Type', 'text/plain')
-      return res.end(`Welcome After ${retryCount}`)
-    }
-  })
+  return {
+    instance
+  }
 }
 
 
+test("a 500 status code with no custom handler should fail", async (t) => {
+  const {instance} = await setupServer(t);
 
-//we want to be able to registerDefaultRetry which will return retryAfter if we have a default cause
-//we want our default handler to use either our own retryAfter value or use it's own
-//
-
-
-//test cases
-// -> a server just 503's and as have a custom handler attached and we register the default
-// -> a server just 503's and we have a custom handler and we don't register the default. expect to 503
-// -> a server 503's and we don't have a custom handler we should still revive
-
-
-// -> a server 500's and we don't have a custom handler we should fail
-// -> a server 500's and we have a custom handler we should revive
-// -> server 500's with a custom handler and we revive but then we 503 without registering we should ultimately fail
-// -> a server 500's with a custom handler and we revive but then we 503 with registering
-
-test('we should revive a 503 ', async function(t) {
-
-  const revival
+  try{
+    await got.get(`http://localhost:${instance.server.address().port}`, { retry: 0 })
+  }catch(error){
+    t.ok(error instanceof got.RequestError, 'should throw RequestError');
+    t.end()
+  }
 })
+
+
+
+// -> a server 500's and we have a custom handler we should revive
+// test("a server 500's with a custom handler and should revive", async (t) => {
+
+//   const {target, instance} = await setupServer(t);
+
+// })
+
+
+
+
+// test('retry a 500 status code in a custom manner', async function (t) {
+//   const customRetryLogic = (req, res, registerDefaultRetry, defaultRetryAfter) => {
+//     if (res && res.statusCode === 500 && req.method === 'GET') {
+//       return 300
+//     }
+//     return null
+//   }
+
+//   const target = internalErrorServerWhichRevives(true)
+//   await target.listen({ port: 0 })
+//   t.teardown(target.close.bind(target))
+
+//   const instance = Fastify()
+//   instance.register(From, {
+//     base: `http://localhost:${target.address().port}`
+//   })
+
+//   instance.get('/', (request, reply) => {
+//     console.log('getting reply from broken serve')
+//     reply.from(`http://localhost:${target.address().port}`, {
+//       customRetry: { retries: 10, handler: customRetryLogic }
+//     })
+//   })
+
+//   t.teardown(instance.close.bind(instance))
+//   await instance.listen({ port: 0 })
+
+//   // ----- End Registering The Fastify Server ---
+
+//   // making a request to the server we setup through fastify
+//   const res = await got.get(`http://localhost:${instance.server.address().port}`, { retry: 0 })
+//   console.log('request to server', { statusCode: res.statusCode, body: res.body.toString()})
+
+//   t.equal(res.headers['content-type'], 'text/plain')
+//   t.equal(res.statusCode, 205)
+//   t.equal(res.body.toString(), 'Hello World 5!')
+// })

--- a/test/retry-on-500.test.js
+++ b/test/retry-on-500.test.js
@@ -6,14 +6,12 @@ const From = require('..')
 const http = require('node:http')
 const got = require('got')
 
-function createTargetServer (withRetryAfterHeader, stopAfter = 4) {
+function internalErrorServerWhichRevives (withRetryAfterHeader, stopAfter = 4) {
   let requestCount = 0
   return http.createServer((req, res) => {
     if (requestCount++ < stopAfter) {
       res.statusCode = 500
       res.setHeader('Content-Type', 'text/plain')
-
-      //this will be ignored because we have a custom retryAfter
       if (withRetryAfterHeader) {
         res.setHeader('Retry-After', 100) // 100 ms
       }
@@ -27,15 +25,18 @@ function createTargetServer (withRetryAfterHeader, stopAfter = 4) {
   })
 }
 
+
+
+
 test('retry a 500 status code in a custom manner', async function (t) {
-  const customRetryLogic = (req, res) => {
+  const customRetryLogic = (req, res, registerDefaultRetry, defaultRetryAfter) => {
     if (res && res.statusCode === 500 && req.method === 'GET') {
       return 300
     }
     return null
   }
 
-  const target = createTargetServer(true)
+  const target = internalErrorServerWhichRevives(true)
   await target.listen({ port: 0 })
   t.teardown(target.close.bind(target))
 
@@ -47,7 +48,7 @@ test('retry a 500 status code in a custom manner', async function (t) {
   instance.get('/', (request, reply) => {
     console.log('getting reply from broken serve')
     reply.from(`http://localhost:${target.address().port}`, {
-      customRetryHandler: { retries: 10, retryHandlerImpl: customRetryLogic }
+      customRetry: { retries: 10, handler: customRetryLogic }
     })
   })
 
@@ -63,4 +64,46 @@ test('retry a 500 status code in a custom manner', async function (t) {
   t.equal(res.headers['content-type'], 'text/plain')
   t.equal(res.statusCode, 205)
   t.equal(res.body.toString(), 'Hello World 5!')
+})
+
+
+
+const create503ServerWhichRevivesAfterRetries = async () => {
+  let retryCount = 0;
+
+  return http.createServer((req, res) => {
+    if (retryCount++ < 2){
+      res.statusCode = 503
+      res.setHeader('Content-Type', 'text/plain')
+      res.setHeader('retry-after', 200)
+      return res.end('This Service is Unavailable')
+    }else{
+      res.statusCode = 205
+      res.setHeader('Content-Type', 'text/plain')
+      return res.end(`Welcome After ${retryCount}`)
+    }
+  })
+}
+
+
+
+//we want to be able to registerDefaultRetry which will return retryAfter if we have a default cause
+//we want our default handler to use either our own retryAfter value or use it's own
+//
+
+
+//test cases
+// -> a server just 503's and as have a custom handler attached and we register the default
+// -> a server just 503's and we have a custom handler and we don't register the default. expect to 503
+// -> a server 503's and we don't have a custom handler we should still revive
+
+
+// -> a server 500's and we don't have a custom handler we should fail
+// -> a server 500's and we have a custom handler we should revive
+// -> server 500's with a custom handler and we revive but then we 503 without registering we should ultimately fail
+// -> a server 500's with a custom handler and we revive but then we 503 with registering
+
+test('we should revive a 503 ', async function(t) {
+
+  const revival
 })

--- a/test/retry-on-500.test.js
+++ b/test/retry-on-500.test.js
@@ -23,18 +23,8 @@ function serverWithCustomError (stopAfter, statusCodeToFailOn) {
   })
 }
 
-//test cases queue
-// -> a server just 503's and as have a custom handler attached and we register the default
-// -> a server just 503's and we have a custom handler and we don't register the default. expect to 503
-// -> a server 503's and we don't have a custom handler we should still revive
-
-
-// -> server 500's with a custom handler and we revive but then we 503 without registering we should ultimately fail
-// -> a server 500's with a custom handler and we revive but then we 503 with registering
-
-
 // -> a server 500's and we don't have a custom handler we should fail
-async function setupServer(t, fromOptions= {}, statusCodeToFailOn = 500, stopAfter = 4){
+async function setupServer(t, fromOptions = {}, statusCodeToFailOn = 500, stopAfter = 4){
   const target = serverWithCustomError(stopAfter, statusCodeToFailOn)
   await target.listen({ port: 0 })
   t.teardown(target.close.bind(target))
@@ -56,7 +46,6 @@ async function setupServer(t, fromOptions= {}, statusCodeToFailOn = 500, stopAft
   }
 }
 
-
 test("a 500 status code with no custom handler should fail", async (t) => {
   const {instance} = await setupServer(t);
 
@@ -67,8 +56,6 @@ test("a 500 status code with no custom handler should fail", async (t) => {
     t.end()
   }
 })
-
-
 
 // -> a server 500's and we have a custom handler we should revive not
 test("a server 500's with a custom handler and should revive", async (t) => {
@@ -87,7 +74,6 @@ test("a server 500's with a custom handler and should revive", async (t) => {
   t.equal(res.statusCode, 205)
   t.equal(res.body.toString(), 'Hello World 5!')
 })
-
 
 // -> server 503's with a custom handler not registering the default should ultimately fail
 test("a server 503's with a custom handler for 500 but the custom handler never registers the default so should fail", async (t) => {
@@ -112,15 +98,13 @@ test("a server 503's with a custom handler for 500 but the custom handler never 
 test("a server 503's with a custom handler for 500 and the custom handler registers the default so it passes", async (t) => {
   const customRetryLogic = (req, res, registerDefaultRetry, defaultRetryAfter) => {
     //registering the default retry logic for non 500 errors if it occurs
-    const defaultHandler = registerDefaultRetry(defaultRetryAfter())
-    if (defaultHandler){
-      return defaultHandler;
+    if (registerDefaultRetry()){
+      return defaultRetryAfter;
     }
 
     if (res && res.statusCode === 500 && req.method === 'GET') {
       return 300
     }
-
 
     return null
   }

--- a/test/retry-on-500.test.js
+++ b/test/retry-on-500.test.js
@@ -89,11 +89,7 @@ test("a server 500's with a custom handler and should revive", async (t) => {
 })
 
 
-
-
-
 // -> server 503's with a custom handler not registering the default should ultimately fail
-
 test("a server 503's with a custom handler for 500 but the custom handler never registers the default so should fail", async (t) => {
   //the key here is we need our customRetryHandler doesn't register the deefault handler and as a result it doesn't work
   const customRetryLogic = (req, res, registerDefaultRetry, defaultRetryAfter) => {
@@ -113,9 +109,9 @@ test("a server 503's with a custom handler for 500 but the custom handler never 
   }
 });
 
-
 test("a server 503's with a custom handler for 500 and the custom handler registers the default so it passes", async (t) => {
   const customRetryLogic = (req, res, registerDefaultRetry, defaultRetryAfter) => {
+    //registering the default retry logic for non 500 errors if it occurs
     const defaultHandler = registerDefaultRetry(defaultRetryAfter())
     if (defaultHandler){
       return defaultHandler;
@@ -137,63 +133,3 @@ test("a server 503's with a custom handler for 500 and the custom handler regist
   t.equal(res.statusCode, 205)
   t.equal(res.body.toString(), 'Hello World 6!')
 });
-
-
-
-// -> server 503's with a custom handler that registers the default handler so we should utilitely revive
-// test("a server 503's with a custom handler for 500 and should revive", async (t) => {
-//   //the key here is we need our customRetryHandler should register the deefault handler and as a result so it ends up working
-
-//   const customRetryLogic = (req, res, registerDefaultRetry, defaultRetryAfter) => {
-
-//     if (res && res.statusCode === 500 && req.method === 'GET') {
-//       return 300
-//     }
-//     return null
-//   }
-
-//   const {instance} = await setupServer(t, {customRetry: { handler: customRetryLogic, retries: 10}}, 503);
-
-//   const res = await got.get(`http://localhost:${instance.server.address().port}`, { retry: 0 })
-
-//   t.equal(res.headers['content-type'], 'text/plain')
-//   t.equal(res.statusCode, 205)
-//   t.equal(res.body.toString(), 'Hello World 5!')
-
-
-// });
-
-
-
-
-// test('retry a 500 status code in a custom manner', async function (t) {
-
-//   const target = internalErrorServerWhichRevives(true)
-//   await target.listen({ port: 0 })
-//   t.teardown(target.close.bind(target))
-
-//   const instance = Fastify()
-//   instance.register(From, {
-//     base: `http://localhost:${target.address().port}`
-//   })
-
-//   instance.get('/', (request, reply) => {
-//     console.log('getting reply from broken serve')
-//     reply.from(`http://localhost:${target.address().port}`, {
-//       customRetry: { retries: 10, handler: customRetryLogic }
-//     })
-//   })
-
-//   t.teardown(instance.close.bind(instance))
-//   await instance.listen({ port: 0 })
-
-//   // ----- End Registering The Fastify Server ---
-
-//   // making a request to the server we setup through fastify
-//   const res = await got.get(`http://localhost:${instance.server.address().port}`, { retry: 0 })
-//   console.log('request to server', { statusCode: res.statusCode, body: res.body.toString()})
-
-//   t.equal(res.headers['content-type'], 'text/plain')
-//   t.equal(res.statusCode, 205)
-//   t.equal(res.body.toString(), 'Hello World 5!')
-// })

--- a/test/retry-on-503.test.js
+++ b/test/retry-on-503.test.js
@@ -13,6 +13,7 @@ function createTargetServer (withRetryAfterHeader, stopAfter = 1) {
       res.statusCode = 503
       res.setHeader('Content-Type', 'text/plain')
       if (withRetryAfterHeader) {
+        console.log("header")
         res.setHeader('Retry-After', 100)
       }
       return res.end('This Service is Unavailable')

--- a/test/retry-on-503.test.js
+++ b/test/retry-on-503.test.js
@@ -13,7 +13,6 @@ function createTargetServer (withRetryAfterHeader, stopAfter = 1) {
       res.statusCode = 503
       res.setHeader('Content-Type', 'text/plain')
       if (withRetryAfterHeader) {
-        console.log("header")
         res.setHeader('Retry-After', 100)
       }
       return res.end('This Service is Unavailable')

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,12 +1,12 @@
-import replyFrom, { FastifyReplyFromOptions } from "..";
-import fastify, {FastifyReply, FastifyRequest, RawServerBase, RequestGenericInterface} from "fastify";
-import { AddressInfo } from "net";
-import { IncomingHttpHeaders } from "http2";
-import { expectType } from 'tsd';
+import fastify, { FastifyReply, FastifyRequest, RawServerBase, RequestGenericInterface } from "fastify";
 import * as http from 'http';
+import { IncomingHttpHeaders } from "http2";
 import * as https from 'https';
+import { AddressInfo } from "net";
+import { expectType } from 'tsd';
+import replyFrom, { FastifyReplyFromOptions } from "..";
 // @ts-ignore
-import tap from 'tap'
+import tap from 'tap';
 
 const fullOptions: FastifyReplyFromOptions = {
   base: "http://example2.com",
@@ -41,7 +41,7 @@ const fullOptions: FastifyReplyFromOptions = {
     pipelining: 10
   },
   contentTypesToEncode: ['application/x-www-form-urlencoded'],
-  retryMethods: ['GET', 'HEAD', 'OPTIONS', 'TRACE'],
+  retryMethods: ['GET', 'HEAD', 'OPTIONS', 'TRACE', 'POST', 'PATCH'],
   maxRetriesOn503: 10,
   disableRequestLogging: false,
   globalAgent: false,


### PR DESCRIPTION
This PR implements a rework of the retry API to succicently handle custom retry callbacks passed to .from(). The API is extended in such a way that the custom retry handler function passed to .from() has an option to either invoke the default retry handler or skip it completely. That is, currently retries on 503's work out of the box with this library but if you add a custom retry handler it is your responsibility to register that default handler otherwise 503's won't be handled.

The purpose and motivation of this PR was to handle custom retries (duh) but more importantly 500's. As a result the test suite for this PR is in respect to 500 errors.